### PR TITLE
pip removed -E/--environment option since version 1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean-elpa:
 	rm -rf elpa
 
 requirements: env
-	pip install --environment $(ENV) --requirement requirements.txt
+	$(ENV)/bin/pip install --requirement requirements.txt
 
 env: $(ENV)/bin/activate
 $(ENV)/bin/activate:


### PR DESCRIPTION
http://www.pip-installer.org/en/latest/news.html#id3
