### PR TITLE
add Package-Requires header for installing dependencies

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2012 Takafumi Arakaki
 
 ;; Author: Takafumi Arakaki <aka.tkf at gmail.com>
+;; Package-Requires: ((epc "0.1.0") (auto-complete "1.4"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
I want to register emacs-jedi to ELPA(MELPA).
It requires version and dependencies information at least.

Please add Version header(I cannot find version information, such as git tag version).

References
- [http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging.html](http://www.gnu.org/software/emacs/manual/html_node/elisp/Packaging.html)
- [http://marmalade-repo.org/doc-files/package.5.html](http://marmalade-repo.org/doc-files/package.5.html)
