### PR TITLE
Modified to work in "BSD make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,8 @@
 ENV = env
-ifndef PYTHON
-	PYTHON = python
-endif
 
-ifndef CARTON
-	CARTON = carton
-endif
-
-ifndef EMACS
-	EMACS = emacs
-endif
+PYTHON ?= python
+CARTON ?= carton
+EMACS ?= emacs
 
 .PHONY : test test-1 tryout clean-elpa requirements env clean-env clean \
 	print-deps travis-ci


### PR DESCRIPTION
el-get-install jedi failed in my FreeBSD box because of lack of GNU make.
This little change works fine both GNU make and BSD make (I suppose...).
