### PR TITLE
Cut completion summary to jedi:max-summary-length

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -334,6 +334,17 @@ See also: `jedi:server-args'."
 
 ;;; AC source
 
+(defcustom jedi:max-summary-length nil
+  "Maximum description length in completions menu."
+  :group 'jedi
+  :type '(choice (const :tag "Unlimited" nil)
+                 (integer :tag "Value" 30)))
+
+(defcustom jedi:cut-summary-postfix ""
+  "Postfix string to be concatenated to shortened completions."
+  :group 'jedi
+  :type 'string)
+
 (defun jedi:ac-direct-matches ()
   (mapcar
    (lambda (x)
@@ -342,7 +353,11 @@ See also: `jedi:server-args'."
        (popup-make-item word
                         :symbol symbol
                         :document (unless (equal doc "") doc)
-                        :summary description)))
+                        :summary (if (and jedi:max-summary-length
+                                          (> (length description) jedi:max-summary-length))
+                                     (concat (substring 0 jedi:max-summary-length description)
+                                             jedi:cut-summary-postfix)))))
+
    jedi:complete-reply))
 
 (defun jedi:ac-direct-prefix ()


### PR DESCRIPTION
Hi, I just changed the patch as requested. I like to have the dots when the completion is being cut, so I made that feature optional instead of completely removing it, hope it's ok :-)
