### PR TITLE
Fixed typo in jedi.el

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -505,7 +505,7 @@ See also: `jedi:server-args'."
       (lambda (candidates-list)
         (funcall
          helm
-         :sources (list (jedi:related-names--source "Jeid Related Names"
+         :sources (list (jedi:related-names--source "Jedi Related Names"
                                                     (car candidates-list))
                         (jedi:related-names--source "Jedi Goto"
                                                     (cadr candidates-list)))


### PR DESCRIPTION
I have no clue about Lisp or Emacs, but there was a typo in `jedi.el` :)

![xkcd 224](http://imgs.xkcd.com/comics/lisp.jpg)

![xkcd 297](http://imgs.xkcd.com/comics/lisp_cycles.png)
