### PR TITLE
jedi:goto-definition--callback to saves the mark to the mark-ring before jumping

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -456,6 +456,7 @@ See also: `jedi:server-args'."
        ((not (and module_path (file-exists-p module_path)))
         (message "File '%s' does not exist." module_path))
        (t
+	(push-mark)
         (funcall (if other-window #'find-file-other-window #'find-file)
                  module_path)
         (goto-char (point-min))


### PR DESCRIPTION
This one liner fixes the issue I raised in https://github.com/tkf/emacs-jedi/issues/26
