### PR TITLE
A way to customize what minor modes jedi:doc can use

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -123,7 +123,7 @@ tooltip in millisecond."
   "Major mode to use when showing document."
   :group 'jedi)
 
-(defcustom jedi:doc-hook nil
+(defcustom jedi:doc-hook '(view-mode)
   "The hook that's run after showing a document."
   :type 'hook
   :group 'jedi)


### PR DESCRIPTION
I set the default jedi:doc minor mode to view-mode, which makes the doc buffers read only.
