### PR TITLE
Set `jedi:server-args` `safe-local-variable` property to `listp`

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -129,7 +129,8 @@ for Jedi.el and other EPC applications.
 
 If you want to start a new ad-hoc server for the current buffer,
 use the command `jedi:start-dedicated-server'."
-  :group 'jedi)
+  :group 'jedi
+  :safe 'listp)
 
 (defcustom jedi:complete-on-dot nil
   "Non-`nil' means automatically start completion after inserting a dot.


### PR DESCRIPTION
Setting the `safe-local-variable` to `listp` allows use of file local variables and directory local variables without the annoying confirmation prompt each time a file is opened.

One possible use case for this is passing the `--virtual-env` argument for each project directory using the `.dir-locals.el` file in the root directory, e.g.

In root project directory `.dir-local.el`:

``` lisp
((nil . ((jedi:server-args . ("--virtual-env" "/path/to/venv")))))
```
