### PR TITLE
Autodetect --virtual-env and --sys-path from python.el settings.

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -713,19 +713,17 @@ See also: `jedi:server-args'."
 This is automatically added to the `jedi-mode-hook' when
 `jedi:import-python-el-settings' is non-nil."
   (let ((args))
-    (and (boundp 'python-shell-extra-pythonpaths)
-         python-shell-extra-pythonpaths
-         (mapc
-          (lambda (path)
-            (setq args (append (list "--sys-path" path) args)))
-          python-shell-extra-pythonpaths))
-    (and (boundp 'python-shell-virtualenv-path)
-         python-shell-virtualenv-path
-         (setq args
-               (append
-                (list "--virtual-env" python-shell-virtualenv-path)
-                args)))
-    (and args (set (make-local-variable 'jedi:server-args) args))))
+    (when (bound-and-true-p python-shell-extra-pythonpaths)
+      (mapc
+       (lambda (path)
+         (setq args (append (list "--sys-path" path) args)))
+       python-shell-extra-pythonpaths))
+    (when (bound-and-true-p python-shell-virtualenv-path)
+      (setq args
+            (append
+             (list "--virtual-env" python-shell-virtualenv-path)
+             args)))
+    (when args (set (make-local-variable 'jedi:server-args) args))))
 
 ;;;###autoload
 (defun jedi:setup ()
@@ -742,14 +740,14 @@ You can also call this function as a command, to quickly test
 what jedi can do."
   (interactive)
   (jedi:ac-setup)
-  (and jedi:import-python-el-settings
-       ;; Hack to access buffer/dir-local vars: http://bit.ly/Y5IfMV.
-       ;; Given that `jedi:setup' is added to the `python-mode-hook'
-       ;; this will modify `hack-local-variables-hook' on python
-       ;; buffers only and will allow us to access buffer/directory
-       ;; local variables in `jedi:import-python-el-settings-setup'.
-       (add-hook 'hack-local-variables-hook
-                 #'jedi:import-python-el-settings-setup nil t))
+  (when jedi:import-python-el-settings
+    ;; Hack to access buffer/dir-local vars: http://bit.ly/Y5IfMV.
+    ;; Given that `jedi:setup' is added to the `python-mode-hook'
+    ;; this will modify `hack-local-variables-hook' on python
+    ;; buffers only and will allow us to access buffer/directory
+    ;; local variables in `jedi:import-python-el-settings-setup'.
+    (add-hook 'hack-local-variables-hook
+              #'jedi:import-python-el-settings-setup nil t))
   (jedi-mode 1))
 
 


### PR DESCRIPTION
Vars:
-  jedi:import-python-el-settings.

Functions:
- jedi:import-python-el-settings-setup.

Fixes #32.
