### PR TITLE
Add separate marker ring for goto-definition calls

### DIFF
--- a/doc/source/tail.rest
+++ b/doc/source/tail.rest
@@ -47,7 +47,6 @@ Command
 .. el:function:: jedi:complete
 .. el:function:: jedi:get-in-function-call
 .. el:function:: jedi:goto-definition
-.. el:function:: jedi:goto-definition-push-marker
 .. el:function:: jedi:goto-definition-pop-marker
 .. el:function:: jedi:show-doc
 

--- a/jedi.el
+++ b/jedi.el
@@ -674,7 +674,7 @@ INDEX-th result."
           (jedi:goto-definition--callback reply other-window)))))))
 
 (defun jedi:goto-definition-push-marker ()
-  (interactive)
+  "Push point onto goto-definition marker ring."
   (ring-insert jedi:goto-definition--marker-ring (point-marker)))
 
 (defun jedi:goto-definition-pop-marker ()


### PR DESCRIPTION
It's made to to facilitate popping back to where `C-.` was invoked.
Default keybinding is `M-*`.

It wasn't too hard, actually.

Feel free to ping me if you insist on having `M-*` key customized like the rest of the keybindings. Feel free to close the issue in favor of the pull-request (issue #42).
