### PR TITLE
remove the option: --use-mirrors for pip in Makefile, in case old pip in...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VIRTUALENV_SYSTEM_SITE_PACKAGES ?= true
 VIRTUALENV = \
 	VIRTUALENV_SYSTEM_SITE_PACKAGES=$(VIRTUALENV_SYSTEM_SITE_PACKAGES) \
 		virtualenv --python=$(PYTHON)
-PIP_INSTALL = $(ENV)/$(BINDIR)/pip install --use-mirrors
+PIP_INSTALL = $(ENV)/$(BINDIR)/pip install
 JEDI_DEV_URL = https://github.com/davidhalter/jedi/archive/dev.zip
 
 PYTHON ?= python


### PR DESCRIPTION
remove option: use-mirrors  for pip install command, in case old-version pip does NOT support it.
