### PR TITLE
jedi:complete: force completion after stop words

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -562,7 +562,7 @@ See: https://github.com/tkf/emacs-jedi/issues/54"
     (deferred:nextc (jedi:complete-request)
       (lambda ()
         (let ((ac-expand-on-auto-complete expand))
-          (ac-start))))))
+          (ac-start :triggered 'command))))))
 ;; Calling `auto-complete' or `ac-update-greedy' instead of `ac-start'
 ;; here did not work.
 


### PR DESCRIPTION
Here's a minimalistic test that fails for me:

``` python
import unittest

unittest.as
```

With point after "as" activating `jedi:complete` does nothing, unlike `auto-complete` which initiates completion successfully. Apparently "as" is considered a stop-word after which completion is usually unwanted (unless requested specifically by a command) and `jedi:complete` doesn't convey the fact that auto-completion is triggered by a command.

I'm by no means an expert in `auto-complete` internals, but the patch works for me.
