### PR TITLE
Restore compatibility with the latest jedi

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -257,10 +257,7 @@ def jedi_epc_server(address='localhost', port=0, port_file=sys.stdout,
 def import_jedi():
     global jedi
     import jedi
-    import jedi.parsing
-    import jedi.evaluate
     import jedi.api
-    return jedi
 
 
 def add_virtualenv_path(venv=os.getenv('VIRTUAL_ENV')):


### PR DESCRIPTION
Restore compatibility with the latest jedi by removing unused jedi imports.

jediepcserver.py imports `jedi.parsing` module but it was removed from jedi. Since `jedi.parsing` as long as `jedi.evaluate` are not used anywhere in jediepcserver.py, we can safely remove them and thus restore the compatibility with jedi.

I discovered there is another pull request #116, but I don't see why we should keep those imports. Am I missing something?
