### PR TITLE
Load cl.el at compiling

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -28,6 +28,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
 (require 'ring)
 
 (require 'epc)


### PR DESCRIPTION
Because older popup-el loads cl.el only at compiling.
(Newer popup-el loads cl.el without `eval-after-load)

This is related to #127

@picca Please try to compiling https://raw.github.com/tkf/emacs-jedi/require-cl/jedi.el .
I merge this patch if you have no problems.
