### PR TITLE
Update dependencies of emacs-jedi

### DIFF
--- a/jedi-pkg.el
+++ b/jedi-pkg.el
@@ -2,4 +2,5 @@
   "0.2.0alpha1"
   "Python auto-completion for Emacs"
   '((epc "0.1.0")
-    (auto-complete "1.4")))
+    (auto-complete "1.4")
+    (python-environment "0")))


### PR DESCRIPTION
`*-pkg.el` file has higher priority than `Package-Requires` header.

Related to #138 
