### PR TITLE
Fix link format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,17 +4,27 @@
 
 .. sidebar:: Links:
 
-   * `Documentation <http://tkf.github.io/emacs-jedi/released>`_
-     (`developmental version <http://tkf.github.io/emacs-jedi/latest>`_)
+   * `Documentation`_
+     (`developmental version`_)
 
-     * `Screenshots <http://tkf.github.io/emacs-jedi/released#screenshots>`_
-     * `Configuration <http://tkf.github.io/emacs-jedi/released#configuration>`_
-     * `Command <http://tkf.github.io/emacs-jedi/released#command>`_
-     * `Troubleshooting <http://tkf.github.io/emacs-jedi/released#troubleshooting>`_
+     * `Screenshots`_
+     * `Configuration`_
+     * `Command`_
+     * `Troubleshooting`_
 
-   * `Repository <https://github.com/tkf/emacs-jedi>`_ (at GitHub)
-   * `Issue tracker <https://github.com/tkf/emacs-jedi/issues>`_ (at GitHub)
-   * `Travis CI <https://travis-ci.org/tkf/emacs-jedi>`_ |build-status|
+   * `Repository`_ (at GitHub)
+   * `Issue tracker`_ (at GitHub)
+   * `Travis CI`_ |build-status|
+
+.. _`Documentation`: http://tkf.github.io/emacs-jedi/released
+.. _`developmental version`: http://tkf.github.io/emacs-jedi/latest
+.. _`Screenshots`: http://tkf.github.io/emacs-jedi/released#screenshots
+.. _`Configuration`: http://tkf.github.io/emacs-jedi/released#configuration
+.. _`Command`: http://tkf.github.io/emacs-jedi/released#command
+.. _`Troubleshooting`: http://tkf.github.io/emacs-jedi/released#troubleshooting
+.. _`Repository`: https://github.com/tkf/emacs-jedi
+.. _`Issue tracker`: https://github.com/tkf/emacs-jedi/issues
+.. _`Travis CI`: https://travis-ci.org/tkf/emacs-jedi
 
 
 What is it?


### PR DESCRIPTION
`reStructuredText`  in github does not work well like ``Link<http://example.com>``.

@tkf Please see this patch, I don't understand `reStructuredText` well.
