### PR TITLE
jediepcserver.py: expand user (~) and env vars in virtual-env argument

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -198,14 +198,21 @@ def get_jedi_version():
     ) for module in [sys, jedi, epc, sexpdata]]
 
 
+def path_expand_vars_and_user(p):
+    return os.path.expandvars(os.path.expanduser(p))
+
+
 def jedi_epc_server(address='localhost', port=0, port_file=sys.stdout,
                     sys_path=[], virtual_env=[],
                     debugger=None, log=None, log_level=None,
                     log_traceback=None):
-    add_virtualenv_path()
+    default_venv = os.getenv('VIRTUAL_ENV')
+    if default_venv:
+        add_virtualenv_path(default_venv)
+
     for p in virtual_env:
-        add_virtualenv_path(p)
-    sys_path = map(os.path.expandvars, map(os.path.expanduser, sys_path))
+        add_virtualenv_path(path_expand_vars_and_user(p))
+    sys_path = map(path_expand_vars_and_user, sys_path)
     sys.path = [''] + list(filter(None, itertools.chain(sys_path, sys.path)))
     # Workaround Jedi's module cache.  Use this workaround until Jedi
     # got an API to set module paths.
@@ -262,10 +269,8 @@ def import_jedi():
     import jedi.api
 
 
-def add_virtualenv_path(venv=os.getenv('VIRTUAL_ENV')):
+def add_virtualenv_path(venv):
     """Add virtualenv's site-packages to `sys.path`."""
-    if not venv:
-        return
     venv = os.path.abspath(venv)
     path = os.path.join(
         venv, 'lib', 'python%d.%d' % sys.version_info[:2], 'site-packages')

--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -258,8 +258,6 @@ def jedi_epc_server(address='localhost', port=0, port_file=sys.stdout,
         server.logger.addHandler(handler)
         server.logger.setLevel(logging.DEBUG)
 
-    server.serve_forever()
-    server.logger.info('exit')
     return server
 
 
@@ -312,7 +310,9 @@ def main(args=None):
         '--ipdb', dest='debugger', const='ipdb', action='store_const',
         help='start ipdb when error occurs.')
     ns = parser.parse_args(args)
-    jedi_epc_server(**vars(ns))
+    server = jedi_epc_server(**vars(ns))
+    server.serve_forever()
+    server.logger.info('exit')
 
 
 if __name__ == '__main__':

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -11,7 +11,7 @@ def osenv(*args, **kwds):
     def putenvs(dct):
         for (k, v) in dct.items():
             if v is None:
-                del os.environ[k]
+                os.environ.pop(k, None)
             else:
                 os.environ[k] = v
     newenv = dict(*args, **kwds)
@@ -23,10 +23,18 @@ def osenv(*args, **kwds):
         putenvs(oldenv)
 
 
-def test_add_virtualenv_path_runs_fine_in_non_virtualenv():
+def test_epc_server_runs_fine_in_non_virtualenv():
     # See: https://github.com/tkf/emacs-jedi/issues/3
     with osenv(VIRTUAL_ENV=None):
-        jep.add_virtualenv_path()
+        jep.jedi_epc_server()
+
+
+def test_epc_server_runs_fine_in_virtualenv():
+    with osenv(VIRTUAL_ENV='/foobar'):
+        jep.jedi_epc_server()
+    import sys
+    venv_path = '/foobar/lib/python%d.%d/site-packages' % sys.version_info[:2]
+    assert venv_path in sys.path
 
 
 def check_defined_names(source, keys, deftree):


### PR DESCRIPTION
I use couple of hosts with different hostnames and expanding `~` in virtualenv paths would simplify such use case a lot.

Also, I couldn't resist tweaking api a bit to separate concerns and make it clearer what's going on.