### PR TITLE
Install jedi 0.8.1.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name='jediepcserver',
     py_modules=['jediepcserver'],
     install_requires=[
-        "jedi>=0.7.0",
+        "jedi==0.8.1",
         "epc>=0.0.4",
         "argparse",
     ],


### PR DESCRIPTION
This is workaround. Latest jedi version 0.8.1-final0 but this is
invalid version for Python. This makes some issue such as #184.

This workaround will be removed if valid version jedi will be released
in the future.