### PR TITLE
Autoload the function `jedi:auto-complete-mode`

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -97,6 +97,7 @@ in their Emacs configuration."
               (looking-back "\\(\\`\\|[^._[:alnum:]]\\)[0-9]+\\."))
     (jedi:complete :expand nil)))
 
+;;;###autoload
 (defun jedi:auto-complete-mode ()
   (let ((map jedi-mode-map))
     (if jedi:complete-on-dot


### PR DESCRIPTION
Without the autoload you need to explicitly load `jedi` otherwise
calling `jedi-mode` fails with `(void-function jedi:auto-complete-mode)`