### PR TITLE
Rename "prefix-arg" in "jedi:dot-complete"

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -87,7 +87,7 @@ in their Emacs configuration."
   "Insert dot and complete code at point."
   (interactive "p")
   (self-insert-command nchars)
-  (unless (or (/= prefix-arg 1) ;; don't complete if inserted 2+ dots
+  (unless (or (/= nchars 1) ;; don't complete if inserted 2+ dots
               (ac-cursor-on-diable-face-p)
               ;; don't complete if the dot is immediately after int literal
               (looking-back "\\(\\`\\|[^._[:alnum:]]\\)[0-9]+\\."))


### PR DESCRIPTION
This patch finishes up the renaming process in #218 and fixes the "Wrong type argument: number-or-marker-p, nil" error that Emacs gives when trying to run "jedi:dot-complete".