### PR TITLE
Support any python version

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -31,6 +31,7 @@ import re
 import itertools
 import logging
 import site
+import glob
 
 jedi = None  # I will load it later
 
@@ -272,10 +273,10 @@ def import_jedi():
 def add_virtualenv_path(venv):
     """Add virtualenv's site-packages to `sys.path`."""
     venv = os.path.abspath(venv)
-    path = os.path.join(
-        venv, 'lib', 'python%d.%d' % sys.version_info[:2], 'site-packages')
-    sys.path.insert(0, path)
-    site.addsitedir(path)
+    paths = glob.glob(os.path.join(
+        venv, 'lib', 'python*', 'site-packages'))
+    for path in paths:
+        site.addsitedir(path)
 
 
 def main(args=None):

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -39,7 +39,7 @@ def test_epc_server_runs_fine_in_virtualenv():
     with osenv(VIRTUAL_ENV=full_venv_path):
         jep.jedi_epc_server()
 
-    venv_path = '{}/lib/python{}.{}/site-packages'.format(full_venv_path,
+    venv_path = '{0}/lib/python{1}.{2}/site-packages'.format(full_venv_path,
                                                           major_version,
                                                           minor_version)
     assert venv_path in sys.path

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -30,10 +30,19 @@ def test_epc_server_runs_fine_in_non_virtualenv():
 
 
 def test_epc_server_runs_fine_in_virtualenv():
-    with osenv(VIRTUAL_ENV='/foobar'):
-        jep.jedi_epc_server()
     import sys
-    venv_path = '/foobar/lib/python%d.%d/site-packages' % sys.version_info[:2]
+    major_version = sys.version_info[:2][0]
+    minor_version = sys.version_info[:2][1]
+    relative_venv_path = ".tox/py{0}{1}".format(major_version,
+                                                minor_version)
+    full_venv_path = os.path.join(os.getcwd(), relative_venv_path)
+
+    with osenv(VIRTUAL_ENV=full_venv_path):
+        jep.jedi_epc_server()
+
+    venv_path = '{}/lib/python{}.{}/site-packages'.format(full_venv_path,
+                                                          major_version,
+                                                          minor_version)
     assert venv_path in sys.path
 
 

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -33,8 +33,7 @@ def test_epc_server_runs_fine_in_virtualenv():
     import sys
     major_version = sys.version_info[:2][0]
     minor_version = sys.version_info[:2][1]
-    relative_venv_path = ".tox/py{0}{1}".format(major_version,
-                                                minor_version)
+    relative_venv_path = ".tox/py"
     full_venv_path = os.path.join(os.getcwd(), relative_venv_path)
 
     with osenv(VIRTUAL_ENV=full_venv_path):

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -40,8 +40,8 @@ def test_epc_server_runs_fine_in_virtualenv():
         jep.jedi_epc_server()
 
     venv_path = '{0}/lib/python{1}.{2}/site-packages'.format(full_venv_path,
-                                                          major_version,
-                                                          minor_version)
+                                                             major_version,
+                                                             minor_version)
     assert venv_path in sys.path
 
 


### PR DESCRIPTION
As per #178, python 3 venv weren't properly added to path for jedi.
Rather than using sys.version to figure out python version, allow any
python version to be added. The code was taken #223 and I fixed failing
testcase. 