### PR TITLE
Do not change after-change-functions when jedi:install-imenu is nil.

### DIFF
--- a/jedi.el
+++ b/jedi.el
@@ -99,9 +99,10 @@ in their Emacs configuration."
     (if jedi:complete-on-dot
         (define-key map "." 'jedi:dot-complete)
       (define-key map "." nil)))
-  (if jedi-mode
-      (add-hook 'after-change-functions 'jedi:after-change-handler nil t)
-    (remove-hook 'after-change-functions 'jedi:after-change-handler t)))
+  (when jedi:install-imenu
+    (if jedi-mode
+        (add-hook 'after-change-functions 'jedi:after-change-handler nil t)
+      (remove-hook 'after-change-functions 'jedi:after-change-handler t))))
 
 ;;;###autoload
 (setq jedi:setup-function #'jedi:ac-setup


### PR DESCRIPTION
If I understand the code correctly, the purpose of `jedi:after-change-handler` is to change the value of `jedi:defined-names--cache`.  
And this value is used for only functions which is related to `jedi` and `imenu`.  
So if `jedi:install-imenu` is `nil`, `jedi:after-change-handler` should not be added to `after-change-functions`. I think this commit will fix #234.
