### PR TITLE
Replace defined_names() with names()

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -176,7 +176,7 @@ def get_names_recursively(definition, parent=None):
 
 
 def defined_names(*args):
-    return list(map(get_names_recursively, jedi.api.defined_names(*args)))
+    return list(map(get_names_recursively, jedi.api.names(*args)))
 
 
 def get_module_version(module):


### PR DESCRIPTION
Use the new jedi method, since `defined_names` has been dropped in 0.11.0 
Fixes #293