### PR TITLE
Remove "param" from signature, required for jedi > 0.9.0

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -100,7 +100,8 @@ def get_in_function_call(*args):
         return dict(
             # p.get_code(False) should do the job.  But jedi-vim use replace.
             # So follow what jedi-vim does...
-            params=[p.get_code().replace('\n', '') for p in call_def.params],
+            params=[p.get_code().replace('\n', '').replace("param ", "") 
+                    for p in call_def.params],
             index=call_def.index,
             call_name=call_def.call_name,
         )


### PR DESCRIPTION
See also what anaconda-mode does: 
https://github.com/proofit404/anaconda-mode/blob/89fc16d50b889a17521084347b28f3011b84e113/anaconda_mode.py#L97

Also see this discussion: https://github.com/davidhalter/jedi/issues/1074