### PR TITLE
jedi:epc--start-epc: disable jedi-mode on error, improve error message

### DIFF
--- a/jedi-core.el
+++ b/jedi-core.el
@@ -458,14 +458,35 @@ connection."
 (defun jedi:epc--start-epc (server-prog server-args)
   "Same as `epc:start-epc', but set query-on-exit flag for
 associated processes to nil."
-  (let ((mngr (jedi:-with-run-on-error
-                  (epc:start-epc server-prog server-args)
-                (display-warning 'jedi "\
+  (let ((mngr
+         (jedi:-with-run-on-error
+             (epc:start-epc server-prog server-args)
+           (let* ((cmdline-args (append (list server-prog) server-args))
+                  (cmd (executable-find server-prog))
+                  (cmd-str (or cmd
+                               (format "nil (%S not found in exec-path)"
+                                       server-prog)))
+                  (virtual-env (getenv "VIRTUAL_ENV"))
+                  (warning-msg (format "
+================================
 Failed to start Jedi EPC server.
+================================
+
+Server arguments: %S
+Actual command: %s
+VIRTUAL_ENV envvar: %S
+
+*** jedi-mode is disabled in %S ***
+Fix the problem and re-enable it.
+
 *** You may need to run \"M-x jedi:install-server\". ***
 This could solve the problem especially if you haven't run the command yet
 since Jedi.el installation or update and if the server complains about
-Python module imports." :error))))
+Python module imports."
+                                       cmdline-args cmd-str virtual-env
+                                       (current-buffer))))
+             (display-warning 'jedi warning-msg :error)
+             (jedi-mode 0)))))
     (set-process-query-on-exit-flag (epc:connection-process
                                      (epc:manager-connection mngr))
                                     nil)


### PR DESCRIPTION
Errors during server startup disable jedi-mode because they will keep coming with
jedi:get-in-function-call-when-idle.

The error message should help troubleshooting the problem.