### PR TITLE
Add jedi:find-file-function to control where outputs are displayed.

### DIFF
--- a/jedi-core.el
+++ b/jedi-core.el
@@ -356,7 +356,7 @@ avoid collision by something like this::
   :group 'jedi)
 
 (defcustom jedi:import-python-el-settings t
-  "Automatically import setting from python.el variables."
+  "Automatically import settings from python.el variables."
   :group 'jedi)
 
 (defcustom jedi:goto-definition-marker-ring-length 16
@@ -367,10 +367,10 @@ avoid collision by something like this::
 ;;; Internal variables
 
 (defvar jedi:get-in-function-call--d nil
-  "Bounded to deferred object while requesting get-in-function-call.")
+  "Bound to deferred object while requesting get-in-function-call")
 
 (defvar jedi:defined-names--singleton-d nil
-  "Bounded to deferred object while requesting defined_names.")
+  "Bound to deferred object while requesting defined_names")
 
 
 ;;; Jedi mode
@@ -836,6 +836,16 @@ INDEX-th result."
   (forward-line (1- line))
   (forward-char column))
 
+(defvar jedi:find-file-function #'jedi:find-file
+  "Function that reads a source file for jedi navigation.
+It must take these arguments: (file-to-read other-window-flag line_number column_number).")
+
+(defun jedi:find-file (file line column other-window)
+  "Default function used by jedi to find a source FILE, LINE= and COLUMN, possibly in OTHER-WINDOW."
+  (funcall (if other-window #'find-file-other-window #'find-file)
+           file)
+  (jedi:goto--line-column line column))
+
 (defun jedi:goto-definition--nth (other-window &optional try-next)
   (let* ((len (length jedi:goto-definition--cache))
          (n jedi:goto-definition--index)
@@ -856,9 +866,7 @@ INDEX-th result."
           (message "File '%s' does not exist." module_path)))
        (t
         (jedi:goto-definition-push-marker)
-        (funcall (if other-window #'find-file-other-window #'find-file)
-                 module_path)
-        (jedi:goto--line-column line_nr column)
+        (jedi:find-file module_path line_nr column other-window)
         (jedi:goto-definition--notify-alternatives len n))))))
 
 (defun jedi:goto-definition--notify-alternatives (len n)


### PR DESCRIPTION
There are times when it would be helpful to be able to put jedi's displays into a particular window or frame.  This can be done with this simple change which allows binding a custom function that finds the file, line and column that jedi provides, thereby controlling where it is displayed.

I hope you will integrate this.  I also fixed a few doc language issues.