### PR TITLE
Add jedi:goto-definition-hook

### DIFF
--- a/jedi-core.el
+++ b/jedi-core.el
@@ -255,6 +255,11 @@ at the top."
   :type 'hook
   :group 'jedi)
 
+(defcustom jedi:goto-definition-hook nil
+  "The hook that's run after jumping to a definition location."
+  :type 'hook
+  :group 'jedi)
+
 (defcustom jedi:doc-display-buffer 'display-buffer
   "A function to be called with a buffer to show document."
   :group 'jedi)
@@ -859,6 +864,7 @@ INDEX-th result."
         (funcall (if other-window #'find-file-other-window #'find-file)
                  module_path)
         (jedi:goto--line-column line_nr column)
+        (run-hooks 'jedi:goto-definition-hook)
         (jedi:goto-definition--notify-alternatives len n))))))
 
 (defun jedi:goto-definition--notify-alternatives (len n)


### PR DESCRIPTION
- Add a hook allowing code to be executed after jumping to a definition.
- For example, I use this to expand any code-folding that is in effect, and call `pulse-momentary-highlight-one-line`

#### Testing
- Made the code change locally, used `add-hook` to add a hook function and confirmed it worked as expected.