### PR TITLE
Ignore all errors when getting completion docstrings

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -203,20 +203,25 @@ class JediEPCHandler(object):
         )
 
     def complete(self, *args):
-        reply = []
-        for comp in self.jedi_script(*args).completions():
+        def _wrap_completion_result(comp):
             try:
                 docstr = comp.docstring()
-            except KeyError:
+            except Exception:
+                logger.warning(
+                    "Cannot get docstring for completion %s", comp, exc_info=1
+                )
                 docstr = ""
-
-            reply.append(dict(
+            return dict(
                 word=comp.name,
                 doc=docstr,
                 description=candidates_description(comp),
                 symbol=candidate_symbol(comp),
-            ))
-        return reply
+            )
+
+        return [
+            _wrap_completion_result(comp)
+            for comp in self.jedi_script(*args).completions()
+        ]
 
     def get_in_function_call(self, *args):
         sig = self.jedi_script(*args).call_signatures()

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -112,3 +112,32 @@ def test_get_in_function_call():
         'index': 0,
         'call_name': 'foo',
     }
+
+
+def test_completion_docstring_raises(monkeypatch):
+    """Test "complete" handler does not fail if "comp.docstring" raises
+
+    Ref. #339
+    """
+    def raise_exception(*args, **kwargs):
+        raise Exception('hello, world')
+
+    monkeypatch.setattr(
+        'jedi.api.classes.Completion.docstring', raise_exception
+    )
+
+    params = _get_jedi_script_params("""
+    import os
+
+    os.chd
+    """)
+    handler = jep.JediEPCHandler()
+    result = handler.complete(*params)
+    assert result == [
+        {
+            'word': 'chdir',
+            'doc': '',
+            'description': 'def chdir',
+            'symbol': 'f',
+        },
+    ]


### PR DESCRIPTION
This PR fixes `complete` request to return empty strings for all exceptions that may be raised from `comp.docstring()` method, not just `KeyError`. 

Should fix #339. 