### PR TITLE
travis.yml: use xenial distro, list emacs versions provided by evm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: false
 language: python
 git:
@@ -28,6 +28,7 @@ before_install:
   - pip install -q virtualenv tox tox-travis
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip
+  - evm list
   - emacs --version
   - cask
   - make before-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
   - "2.7"
 env:
   matrix:
-    - EVM_EMACS=emacs-26.1-travis
+    - EVM_EMACS=emacs-26.3-travis-linux-xenial
   global:
   # Turn on --use-mirrors option everywhere (even in tox):
   - PIP_USE_MIRRORS=t
@@ -23,6 +23,9 @@ matrix:
     - env: EVM_EMACS=emacs-25.1-travis
     - env: EVM_EMACS=emacs-25.2-travis
     - env: EVM_EMACS=emacs-25.3-travis
+    - env: EVM_EMACS=emacs-26.1-travis-linux-xenial
+    - env: EVM_EMACS=emacs-26.2-travis-linux-xenial
+    - env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 
 before_install:
   - pip install -q virtualenv tox tox-travis


### PR DESCRIPTION
With Trusty already EOLed we need to migrate to Xenial soon.