### PR TITLE
this fixes so you can run jedi:goto-definition from inside an org-bab…

### DIFF
--- a/jedi-core.el
+++ b/jedi-core.el
@@ -43,9 +43,12 @@
 
 (defconst jedi:version "0.2.8")
 
-(defvar jedi:source-dir (if load-file-name
-                            (file-name-directory load-file-name)
-                          default-directory))
+(defvar jedi:source-dir
+  (if (string-match "\*Org Src" (buffer-name (current-buffer)))
+      (file-name-directory (buffer-file-name (org-src-source-buffer (current-buffer))))
+    (if load-file-name
+        (file-name-directory load-file-name)
+      default-directory)))
 
 (defvar jedi:epc nil)
 (make-variable-buffer-local 'jedi:epc)

--- a/jedi-core.el
+++ b/jedi-core.el
@@ -714,7 +714,10 @@ See also: `jedi:server-args'."
 (defun jedi:-buffer-file-name ()
   "Return `buffer-file-name' without text properties.
 See: https://github.com/tkf/emacs-jedi/issues/54"
-  (substring-no-properties (or (buffer-file-name) "")))
+  (substring-no-properties (or (if (string-match "\*Org Src" (buffer-name (current-buffer)))
+                                   (buffer-file-name (org-src-source-buffer))
+                                 (buffer-file-name))
+                               "")))
 
 (defun jedi:call-deferred (method-name)
   "Call ``Script(...).METHOD-NAME`` and return a deferred object."


### PR DESCRIPTION
…el src-code dedicated buffer - opened with C-c '