### PR TITLE
Jedi 0.18 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
+os: linux
 dist: xenial
-sudo: false
 language: python
 git:
   depth: 3
 python:
   # First python version in this list is the default for matrix.include
-  # - "3.7"
+  - "3.7"
+  - "3.9"
+  - "3.8"
   - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
 env:
   matrix:
     - EVM_EMACS=emacs-26.3-travis-linux-xenial
@@ -18,22 +17,26 @@ env:
   - PIP_USE_MIRRORS=t
 matrix:
   include:
-    - env: EVM_EMACS=emacs-24.4-travis
-    - env: EVM_EMACS=emacs-24.5-travis
     - env: EVM_EMACS=emacs-25.1-travis
     - env: EVM_EMACS=emacs-25.2-travis
     - env: EVM_EMACS=emacs-25.3-travis
     - env: EVM_EMACS=emacs-26.1-travis-linux-xenial
-    - env: EVM_EMACS=emacs-26.2-travis-linux-xenial
+    - env: EVM_EMACS=emacs-26.3-travis-linux-xenial
+    - env: EVM_EMACS=emacs-27.1-travis-linux-xenial
     - env: EVM_EMACS=emacs-git-snapshot-travis-linux-xenial
 
 before_install:
   - pip install -q virtualenv tox tox-travis
-  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - curl -fsSL https://raw.githubusercontent.com/cask/cask/v0.8.5/go | python
+  - export PATH="/home/travis/.cask/bin:$PATH"
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm config path /tmp
   - evm install $EVM_EMACS --use --skip
   - evm list
   - emacs --version
   - cask
   - make before-test
+
 script:
   make travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ python:
   - "3.5"
   - "2.7"
 env:
-  matrix:
+  jobs:
     - EVM_EMACS=emacs-27.1-travis-linux-xenial
   global:
     # Turn on --use-mirrors option everywhere (even in tox):
     - PIP_USE_MIRRORS=t
-matrix:
+jobs:
   include:
     - env: EVM_EMACS=emacs-25.1-travis
     - env: EVM_EMACS=emacs-25.2-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ python:
   - "3.9"
   - "3.8"
   - "3.6"
+  - "3.5"
+  - "2.7"
 env:
   matrix:
-    - EVM_EMACS=emacs-26.3-travis-linux-xenial
+    - EVM_EMACS=emacs-27.1-travis-linux-xenial
   global:
-  # Turn on --use-mirrors option everywhere (even in tox):
-  - PIP_USE_MIRRORS=t
+    # Turn on --use-mirrors option everywhere (even in tox):
+    - PIP_USE_MIRRORS=t
 matrix:
   include:
     - env: EVM_EMACS=emacs-25.1-travis

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ ELPA_DIR = $(shell EMACS=$(EMACS) $(CASK) package-directory)
 # See: cask-elpa-dir
 
 VIRTUAL_EMACS = ${CASK} exec ${EMACS} -Q \
---eval "(setq python-environment--verbose t)" \
 --eval "(setq jedi:environment-root \"$(ENV)\")"
 
 .PHONY : test test-1 tryout clean-elpa requirements env clean-env clean \

--- a/jedi-core.el
+++ b/jedi-core.el
@@ -714,15 +714,15 @@ See: https://github.com/tkf/emacs-jedi/issues/54"
   (substring-no-properties (or (buffer-file-name) "")))
 
 (defun jedi:call-deferred (method-name)
-  "Call ``Script(...).METHOD-NAME`` and return a deferred object."
+  "Call ``Script(...).METHOD-NAME()`` and return a deferred object."
   (let ((source      (buffer-substring-no-properties (point-min) (point-max)))
+        (source-path (jedi:-buffer-file-name))
         ;; line=0 is an error for jedi, but is possible for empty buffers.
         (line        (max 1 (count-lines (point-min) (min (1+ (point)) (point-max)))))
-        (column      (- (point) (line-beginning-position)))
-        (source-path (jedi:-buffer-file-name)))
+        (column      (- (point) (line-beginning-position))))
     (epc:call-deferred (jedi:get-epc)
                        method-name
-                       (list source line column source-path))))
+                       (list source source-path line column))))
 
 
 ;;; Completion
@@ -1028,13 +1028,13 @@ It must take these arguments: (file-to-read other-window-flag line_number column
                  initially (erase-buffer)
                  for def in reply
                  do (cl-destructuring-bind
-                        (&key doc desc_with_module &allow-other-keys)
+                        (&key doc full_name &allow-other-keys)
                         def
                       (unless (or (null doc) (equal doc ""))
                         (if first
                             (setq first nil)
                           (insert "\n\n---\n\n"))
-                        (insert "Docstring for " desc_with_module "\n\n" doc)
+                        (insert "Docstring for " full_name "\n\n" doc)
                         (setq has-doc t)))
                  finally do
                  (if (not has-doc)

--- a/jedi-core.el
+++ b/jedi-core.el
@@ -2,7 +2,7 @@
 
 ;; Author: Takafumi Arakaki <aka.tkf at gmail.com>
 ;; Package-Requires: ((emacs "24") (epc "0.1.0") (python-environment "0.0.2") (cl-lib "0.5"))
-;; Version: 0.2.8
+;; Version: 0.3.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -41,7 +41,7 @@
   :group 'completion
   :prefix "jedi:")
 
-(defconst jedi:version "0.2.8")
+(defconst jedi:version "0.3.0")
 
 (defvar jedi:source-dir (if load-file-name
                             (file-name-directory load-file-name)

--- a/jedi-core.el
+++ b/jedi-core.el
@@ -722,7 +722,7 @@ See: https://github.com/tkf/emacs-jedi/issues/54"
         (column      (- (point) (line-beginning-position))))
     (epc:call-deferred (jedi:get-epc)
                        method-name
-                       (list source source-path line column))))
+                       (list source line column source-path))))
 
 
 ;;; Completion

--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -194,12 +194,12 @@ class JediEPCHandler(object):
         result['sys_path'] = [p for p in final_sys_path if not_seen_yet(p)]
         return result
 
-    def jedi_script(self, source, line, column, source_path):
+    def jedi_script(self, source, source_path):
         if NEED_ENCODE:
             source = source.encode('utf-8')
             source_path = source_path and source_path.encode('utf-8')
         return jedi.Script(
-            source, line, column, source_path or '', **self.script_kwargs
+            code=source,  path=source_path or '', **self.script_kwargs
         )
 
     def complete(self, *args):
@@ -217,14 +217,15 @@ class JediEPCHandler(object):
                 description=candidates_description(comp),
                 symbol=candidate_symbol(comp),
             )
-
+        source, line, column, source_path = args
         return [
             _wrap_completion_result(comp)
-            for comp in self.jedi_script(*args).completions()
+            for comp in self.jedi_script(source, source_path).complete(line, column)
         ]
 
     def get_in_function_call(self, *args):
-        sig = self.jedi_script(*args).call_signatures()
+        source, line, column, source_path = args
+        sig = self.jedi_script(source, source_path).get_signatures(line, column)
         call_def = sig[0] if sig else None
 
         if not call_def:
@@ -250,34 +251,31 @@ class JediEPCHandler(object):
         # `definitions` is a list. Each element is an instances of
         # `jedi.api_classes.BaseOutput` subclass, i.e.,
         # `jedi.api_classes.RelatedName` or `jedi.api_classes.Definition`.
-        definitions = method(self.jedi_script(*args))
+        source, line, column, source_path = args
+        definitions = method(self.jedi_script(source, source_path), line, column)
         return [dict(
             column=d.column,
             line_nr=d.line,
-            module_path=d.module_path if d.module_path != '__builtin__' else [],
+            module_path=str(d.module_path) if d.module_path != '__builtin__' else [],
             module_name=d.module_name,
             description=d.description,
         ) for d in definitions]
 
     def goto(self, *args):
-        return self._goto(jedi.Script.goto_assignments, *args)
+        return self._goto(jedi.Script.goto, *args)
 
     def related_names(self, *args):
-        return self._goto(jedi.Script.usages, *args)
+        return self._goto(jedi.Script.get_references, *args)
 
     def get_definition(self, *args):
-        definitions = self.jedi_script(*args).goto_definitions()
+        source, line, column, source_path = args
+        definitions = self.jedi_script(source, source_path).infer(line, column)
         return [definition_to_dict(d) for d in definitions]
 
     def defined_names(self, *args):
-        # XXX: there's a bug in Jedi that returns returns definitions from inside
-        # classes or functions even though all_scopes=False is set by
-        # default. Hence some additional filtering is in order.
-        #
-        # See https://github.com/davidhalter/jedi/issues/1202
         top_level_names = [
             defn
-            for defn in jedi.api.names(*args)
+            for defn in self.jedi_script(*args).get_names()
             if defn.parent().type == 'module'
         ]
         return list(map(get_names_recursively, top_level_names))
@@ -295,7 +293,7 @@ def candidate_symbol(comp):
     Return a character representing completion type.
 
     :type comp: jedi.api.Completion
-    :arg  comp: A completion object returned by `jedi.Script.completions`.
+    :arg  comp: A completion object returned by `jedi.Script.complete`.
 
     """
     try:
@@ -326,10 +324,10 @@ def definition_to_dict(d):
     return dict(
         doc=d.docstring(),
         description=d.description,
-        desc_with_module=d.desc_with_module,
+        desc_with_module=d.full_name,
         line_nr=d.line,
         column=d.column,
-        module_path=d.module_path,
+        module_path=str(d.module_path),
         name=getattr(d, 'name', []),
         full_name=getattr(d, 'full_name', []),
         type=getattr(d, 'type', []),

--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -245,7 +245,7 @@ class JediEPCHandler(object):
             source_path = source_path and source_path.encode('utf-8')
         return jedi_script_wrapper(code=source, path=source_path, **self.script_kwargs)
 
-    def complete(self, source, source_path, line, column):
+    def complete(self, source, line, column, source_path):
         def _wrap_completion_result(comp):
             try:
                 docstr = comp.docstring()
@@ -265,7 +265,7 @@ class JediEPCHandler(object):
             for comp in self.jedi_script(source, source_path).complete(line, column)
         ]
 
-    def get_in_function_call(self, source, source_path, line, column):
+    def get_in_function_call(self, source, line, column, source_path):
         sig = self.jedi_script(source, source_path).get_signatures(line, column)
         call_def = sig[0] if sig else None
 
@@ -281,15 +281,15 @@ class JediEPCHandler(object):
             call_name=call_def.name,
         )
 
-    def goto(self, source, source_path, line, column):
+    def goto(self, source, line, column, source_path):
         definitions = self.jedi_script(source, source_path).goto(line, column)
         return [definition_to_short_dict(d) for d in definitions]
 
-    def related_names(self, source, source_path, line, column):
+    def related_names(self, source, line, column, source_path):
         definitions = self.jedi_script(source, source_path).get_references(line, column)
         return [definition_to_short_dict(d) for d in definitions]
 
-    def get_definition(self, source, source_path, line, column):
+    def get_definition(self, source, line, column, source_path):
         definitions = self.jedi_script(source, source_path).infer(line, column)
         return [definition_to_dict(d) for d in definitions]
 

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ Note: If you are using Windows, then Jedi.el will not work with distutils.
 
 setup(
     name='jediepcserver',
-    version='0.2.8',
+    version='0.3.0',
     py_modules=['jediepcserver'],
     install_requires=[
-        "jedi>=0.11.0",
+        "jedi>=0.18.0",
         "epc>=0.0.4",
         "argparse",
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ setup(
     version='0.3.0',
     py_modules=['jediepcserver'],
     install_requires=[
-        "jedi>=0.11.0; python_version>'3.5'",
-        "jedi>=0.11.0,<0.18.0; python_version<='3.5'",
+        "jedi>=0.11.0",
         "epc>=0.0.4",
         "argparse",
     ],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
     version='0.3.0',
     py_modules=['jediepcserver'],
     install_requires=[
-        "jedi>=0.18.0",
+        "jedi>=0.11.0; python_version>'3.5'",
+        "jedi>=0.11.0,<0.18.0; python_version<='3.5'",
         "epc>=0.0.4",
         "argparse",
     ],

--- a/test-jedi.el
+++ b/test-jedi.el
@@ -87,11 +87,14 @@ json.load
 "
     (goto-char (1- (point-max)))
     (let ((reply (jedi-testing:sync (jedi:call-deferred 'goto))))
-      (destructuring-bind (&key line_nr module_path
-                                column module_name description)
+      (destructuring-bind (&key column line_nr module_path
+                                module_name description)
           (car reply)
+        (should (integerp column))
         (should (integerp line_nr))
-        (should (stringp module_path))))))
+        (should (stringp module_path))
+        (should (stringp module_name))
+        (should (stringp description))))))
 
 (ert-deftest jedi:get-definition-request ()
   (with-python-temp-buffer
@@ -101,14 +104,17 @@ json.load
 "
     (goto-char (1- (point-max)))
     (let ((reply (jedi-testing:sync (jedi:call-deferred 'get_definition))))
-      (destructuring-bind (&key doc desc_with_module line_nr column module_path
-                                full_name name type description)
+      (destructuring-bind (&key doc description line_nr column module_path
+                                name full_name type)
           (car reply)
         (should (stringp doc))
-        (should (stringp desc_with_module))
+        (should (stringp description))
         (should (integerp line_nr))
         (should (integerp column))
-        (should (stringp module_path))))))
+        (should (stringp module_path))
+        (should (stringp name))
+        (should (stringp full_name))
+        (should (stringp type))))))
 
 (ert-deftest jedi:show-version-info ()
   (kill-buffer (get-buffer-create "*jedi:version*"))
@@ -296,7 +302,7 @@ if True:
       (search-forward "func(x)")
       (goto-char (match-beginning 0))
       (let ((reply (jedi-testing:sync (jedi:call-deferred 'get_definition))))
-        (destructuring-bind (&key doc desc_with_module line_nr column module_path
+        (destructuring-bind (&key doc line_nr column module_path
                                   full_name name type description)
             (car reply)
           (should (= line_nr def-line)))))))

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -95,7 +95,7 @@ def test_defined_names_nested_classes():
 def _get_jedi_script_params(src, filename='example.py'):
     source = textwrap.dedent(src)
     lines = source.splitlines()
-    return source, len(lines), len(lines[-1]), filename
+    return source, filename, len(lines), len(lines[-1])
 
 
 def test_get_in_function_call():

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -95,7 +95,7 @@ def test_defined_names_nested_classes():
 def _get_jedi_script_params(src, filename='example.py'):
     source = textwrap.dedent(src)
     lines = source.splitlines()
-    return source, filename, len(lines), len(lines[-1])
+    return source, len(lines), len(lines[-1]), filename
 
 
 def test_get_in_function_call():

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,8 @@ envlist = py{27,35,36,37,38,39}, py{27,36}-jedi11
 [testenv]
 deps =
   pytest
-  jedi>=0.11.0;python_version>'3.5'
-  jedi>=0.11.0,<0.18.0;python_version<='3.5'
+  jedi>=0.11.0
 commands = py.test {posargs} test_jediepcserver.py
-
-[testenv:py{27,36}-jedi11]
-deps =
-  pytest
-  jedi==0.11.1
-
 
 [pytest]
 usefixtures = clean_jedi_cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,18 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py{27,35,36,37,38,39}, py{27,36}-jedi11
 
 [testenv]
 deps =
   pytest
-  jedi>=0.18.0
+  jedi>=0.11.0;python_version>'3.5'
+  jedi>=0.11.0,<0.18.0;python_version<='3.5'
 commands = py.test {posargs} test_jediepcserver.py
+
+[testenv:py{27,36}-jedi11]
+deps =
+  pytest
+  jedi==0.11.1
+
 
 [pytest]
 usefixtures = clean_jedi_cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37
+envlist = py36, py37, py38, py39
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py27, py34, py35, py36, py27-jedi{11,12}, py36-jedi{11,12}
+envlist = py34, py35, py36, py37
 
 [testenv]
 deps =
   pytest
-  py{27,36}-jedi11: jedi==0.11.1
-  py{27,36}-jedi12: jedi==0.12.1
+  jedi>=0.18.0
 commands = py.test {posargs} test_jediepcserver.py
 
 [pytest]


### PR DESCRIPTION
I noticed the completion was broken after upgrading my emacs setup and looked a bit into it.

Jedi 0.18 seems to drop old, unmaintained python releases and to rename a few class/methods, breaking the epcserver (emit a warning in 0.17.X) :
    - line / column are now passed at the method call instead of the jedi.Script init. I didn't want to break the epcserver interface so I've just split the *args to dispatch the parameter where needed. 
    - renamed a few calls (call_signatures is now get_signatures, ...)
    - the desc_with_module attribute is no more available in jedi api (no replacement for now). I've put full_name instead so the method call don't fail but we may want some other value here.

So far, the completion/definition jump is back (using latest company-jedi and fresh emacs master build) but some more exhaustive tests may be required to ensure all features are ok.

Changes are not compatible with older jedi version thus 0.18+ is enforced in setup and test configuration, and the version was bumped to 0.3.0.

This can probably help to fix #348, fix #352, fix #353.

Feel free to comment / request changes.