### PR TITLE
Update sphinx-eldomain submodule to use https URL.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "doc/eldomain"]
 	path = doc/eldomain
-	url = git://github.com/tkf/sphinx-eldomain.git
+	url = https://github.com/tkf/sphinx-eldomain.git


### PR DESCRIPTION
Github no longer permits unencrypted methods like http:// or git://, resulting in an error like:
```
  The unauthenticated git protocol on port 9418 is no longer supported.
```
Using https:// avoids the issue.