### PR TITLE
Fix complete with multiple environments for jedi >= 0.18.0

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -170,6 +170,14 @@ if JEDI_VERSION < pkg_resources.parse_version('0.16.0'):
 
     jedi_script_wrapper = JediScriptCompatWrapper
 
+elif JEDI_VERSION >= pkg_resources.parse_version('0.18.0'):
+    def script_wrapper(code, path, **kwargs):
+        project = jedi.api.Project(path, sys_path=kwargs.pop('sys_path', []))
+        kwargs['project'] = project
+        return jedi.Script(code=code, path=path, **kwargs)
+
+    jedi_script_wrapper = script_wrapper
+
 
 def get_venv_sys_path(venv):
     if jedi_create_environment is not None:
@@ -236,6 +244,7 @@ class JediEPCHandler(object):
                 return False
             dupes.add(val)
             return True
+
         result['sys_path'] = [p for p in final_sys_path if not_seen_yet(p)]
         return result
 

--- a/test_jediepcserver.py
+++ b/test_jediepcserver.py
@@ -36,7 +36,6 @@ def test_epc_server_runs_fine_in_virtualenv():
     subprocess.check_call(['tox', '-e', envname, '--notest'])
     relative_venv_path = ".tox/" + envname
     full_venv_path = os.path.join(os.getcwd(), relative_venv_path)
-
     handler = jep.JediEPCHandler(virtual_envs=[full_venv_path])
     sys_path = handler.get_sys_path()
     venv_path = '{0}/lib/python{1}.{2}/site-packages'.format(
@@ -137,6 +136,33 @@ def test_completion_docstring_raises(monkeypatch):
         {
             'word': 'chdir',
             'doc': '',
+            'description': 'def chdir',
+            'symbol': 'f',
+        },
+    ]
+
+
+def test_compelte_with_multiple_virtualenvs():
+    params = _get_jedi_script_params("""
+    import os
+
+    os.chd
+    """)
+
+    def create_venv(envname):
+        subprocess.check_call(['tox', '-e', envname, '--notest'])
+        relative_venv_path = ".tox/" + envname
+        full_venv_path = os.path.join(os.getcwd(), relative_venv_path)
+        return full_venv_path
+
+    venv = create_venv('some-env')
+    other_venv = create_venv('other-env')
+    handler = jep.JediEPCHandler(virtual_envs=[venv, other_venv])
+    result = handler.complete(*params)
+    assert result == [
+        {
+            'word': 'chdir',
+            'doc': 'chdir(path: _FdOrAnyPath) -> None',
             'description': 'def chdir',
             'symbol': 'f',
         },


### PR DESCRIPTION
From jedi 0.18.0, jedi.Script does not have a sys_path param anymore. To use a customized sys_path now requires the use of jedi.api.Project