### PR TITLE
fix setup tools deprecation pkg_resource warning manging Jedi/Emacs communication

### DIFF
--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -34,6 +34,8 @@ import os
 import re
 import site
 import sys
+import warnings
+warnings.filterwarnings('ignore', category=DeprecationWarning, message='^pkg_resources is deprecated')
 import pkg_resources
 from collections import namedtuple
 

--- a/jediepcserver.py
+++ b/jediepcserver.py
@@ -36,6 +36,7 @@ import site
 import sys
 import warnings
 warnings.filterwarnings('ignore', category=DeprecationWarning, message='^pkg_resources is deprecated')
+warnings.filterwarnings('ignore', category=UserWarning, message='^pkg_resources is deprecated')
 import pkg_resources
 from collections import namedtuple
 


### PR DESCRIPTION
After installing Python 11 and installing the latest setup tools, Emacs JEDI stopped working because a warning message mangled the JEDI/Emacs communication.

The setuptools under version 69.0.2 has deprecated the `pkg_resources` module and produces this warning when loading `jediepcserver.py`:

```
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

This pull request simply adds a warning ignore to suppress it matching on the category and error message.  Per the URL given, it will need to be replaced with `importlib` at some point, but this at least this fixes it for the short term.